### PR TITLE
Support Linux, and fix ScriptPluginFactory build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'kotlin-multiplatform' version '1.3.10'
+    id 'kotlin-multiplatform' version '1.3.61'
 }
 repositories {
     mavenCentral()
@@ -12,21 +12,29 @@ apply plugin: 'maven-publish'
 
 kotlin {
     targets {
-//        fromPreset(presets.jvm, 'jvm')
-        // This preset is for iPhone emulator
-        // Switch here to presets.iosArm64 to build library for iPhone device
-        fromPreset(presets.macosX64, 'native') 
+        if (System.getProperty("os.name") == "Linux") {
+            fromPreset(presets.linuxX64, 'native')
+        } else if (System.getProperty("os.name") == "Mac OS X") {
+            // Switch here to presets.iosArm64 to build library for iPhone device
+            fromPreset(presets.macosX64, 'native')
+
+        }
+
+        // Untested, but should work:
+        // } else if (System.getProperty("os.name").startsWith("Windows")) {
+        //    fromPreset(presets.mingwX64, 'native')
+        // }
     }
     sourceSets {
         commonMain {
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
-                implementation 'co.touchlab:stately:0.5.1-M0.3-SNAPSHOT'
+                implementation 'co.touchlab:stately:0.9.6'
             }
         }
         commonTest {
             dependencies {
-                implementation 'co.touchlab:testhelp:0.1.1-M0.3-SNAPSHOT'
+                implementation 'co.touchlab:testhelp:0.2.9-SNAPSHOT'
                 implementation 'org.jetbrains.kotlin:kotlin-test-common'
                 implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/nativeTest/kotlin/sample/FreezeTests.kt
+++ b/src/nativeTest/kotlin/sample/FreezeTests.kt
@@ -40,7 +40,10 @@ class FreezeTests{
       it()
     }
 
-    assertNull(future.result)
+    assertFails {
+      // job throws, because count is frozen
+      future.result
+    }
     assertEquals(0, count)
     assertTrue(count.isFrozen)
   }

--- a/src/nativeTest/kotlin/sample/GlobalStateTests.kt
+++ b/src/nativeTest/kotlin/sample/GlobalStateTests.kt
@@ -13,11 +13,15 @@ class GlobalStateTests{
   @Test
   fun globalVal(){
     assertFalse(globalState.isFrozen)
-    worker.execute(TransferMode.SAFE,{}){
+    val workerFuture = worker.execute(TransferMode.SAFE,{}){
       assertFails {
         println(globalState.s)
       }
-    }.result
+    }
+
+    assertFails{
+      workerFuture.result
+    }
   }
 
   @Test

--- a/src/nativeTest/kotlin/sample/WorkerTest.kt
+++ b/src/nativeTest/kotlin/sample/WorkerTest.kt
@@ -42,10 +42,8 @@ class WorkerTest {
   @Test
   fun stillVisible() {
     val holder = ArgHolder(JobArg("Hi"))
-    assertFails {
-      worker.execute(TransferMode.SAFE, { holder.getAndClear() }) {
-        println(it)
-      }
+    worker.execute(TransferMode.SAFE, { holder.getAndClear() }) {
+      println(it)
     }
   }
 


### PR DESCRIPTION
* Update gradle version to fix build error
* With new gradle version, got compiler mismatch so had to update kotlin-multiplatform gradle plugin
* Prior versions of Stately and testhelp didn't support linux, so update those

After doing all the above, some tests fail (kotlin/native behavior has seemingly changed since the article),
so update them accordingly.


The OS detection could be more elegant via buildSrc but I figured that was too complex for a repo based on an article.  

Fixes #1 (at least for Linux) and #2 